### PR TITLE
Bump version to 1.0.2

### DIFF
--- a/insideout/SKILL.md
+++ b/insideout/SKILL.md
@@ -9,7 +9,7 @@ description: >
   for cloud infrastructure.
 metadata:
   short-description: Design, deploy & manage cloud infrastructure
-version: 1.0.1
+version: 1.0.2
 ---
 
 # InsideOut -- Agentic Infrastructure Builder & Manager


### PR DESCRIPTION
## Summary
- Bump SKILL.md version to 1.0.2 for release

## Test plan
- [ ] Merge, then tag v1.0.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)